### PR TITLE
Order executed middleware stack in reverse

### DIFF
--- a/src/SlimRouteAttributeProvider.php
+++ b/src/SlimRouteAttributeProvider.php
@@ -46,7 +46,11 @@ final class SlimRouteAttributeProvider implements RouteAttributeProviderInterfac
             $routeMap->setName($routeName);
         }
 
-        foreach ($route->getMiddleware() as $middleware) {
+        /**
+         * Slims order of execution of middleware feels counterintuitive,
+         * therefore, reverse the order of the middleware, so that the first set middleware will be executed first.
+         */
+        foreach (array_reverse($route->getMiddleware()) as $middleware) {
             $routeMap->addMiddleware($this->container->get($middleware));
         }
     }

--- a/tests/SlimRouteAttributeProviderTest.php
+++ b/tests/SlimRouteAttributeProviderTest.php
@@ -7,10 +7,11 @@ namespace Jerowork\RouteAttributeProvider\Slim\Test;
 use Jerowork\RouteAttributeProvider\Api\RequestMethod;
 use Jerowork\RouteAttributeProvider\Api\Route;
 use Jerowork\RouteAttributeProvider\Slim\SlimRouteAttributeProvider;
+use Jerowork\RouteAttributeProvider\Slim\Test\Stub\StubMiddlewareA;
+use Jerowork\RouteAttributeProvider\Slim\Test\Stub\StubMiddlewareB;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Slim\App;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteInterface;
@@ -55,17 +56,28 @@ final class SlimRouteAttributeProviderTest extends MockeryTestCase
 
         $container->expects('get')
             ->once()
-            ->with(stdClass::class)
-            ->andReturn($middleware = Mockery::mock(MiddlewareInterface::class));
+            ->with(StubMiddlewareA::class)
+            ->andReturn($middlewareA = new StubMiddlewareA());
+
+        $container->expects('get')
+            ->once()
+            ->with(StubMiddlewareB::class)
+            ->andReturn($middlewareB = new StubMiddlewareB());
 
         $map->expects('addMiddleware')
+            ->ordered()
             ->once()
-            ->with($middleware);
+            ->with($middlewareB);
+
+        $map->expects('addMiddleware')
+            ->ordered()
+            ->once()
+            ->with($middlewareA);
 
         $provider->configure(
             stdClass::class,
             '__invoke',
-            new Route('/root', name: 'root.name', middleware: stdClass::class)
+            new Route('/root', name: 'root.name', middleware: [StubMiddlewareA::class, StubMiddlewareB::class])
         );
     }
 }

--- a/tests/Stub/StubMiddlewareA.php
+++ b/tests/Stub/StubMiddlewareA.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jerowork\RouteAttributeProvider\Slim\Test\Stub;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class StubMiddlewareA implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/tests/Stub/StubMiddlewareB.php
+++ b/tests/Stub/StubMiddlewareB.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jerowork\RouteAttributeProvider\Slim\Test\Stub;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class StubMiddlewareB implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
# Description
Slims order of execution of middlewareis is executed in reversed order and feels counterintuitive. Therefore, reverse the order of the middleware, so that the first set middleware will be executed first.

Solves #2 